### PR TITLE
fixes #40 (The expression of an export assignment must be...)

### DIFF
--- a/src/xendit.d.ts
+++ b/src/xendit.d.ts
@@ -10,9 +10,9 @@ import { EWalletService } from './ewallet';
 import { BalanceServices } from './balance';
 import { RetailOutletService } from './retail_outlet';
 
-export = class Xendit {
+declare class Xendit {
   constructor(opts: XenditOptions);
-  static Errors = Errors;
+  static Errors;
   Card: typeof CardService;
   VirtualAcc: typeof VAService;
   Disbursement: typeof DisbursementService;
@@ -22,4 +22,5 @@ export = class Xendit {
   EWallet: typeof EWalletService;
   Balance: typeof BalanceServices;
   RetailOutlet: typeof RetailOutletService;
-};
+}
+export = Xendit;


### PR DESCRIPTION
- fixes #40
- Comply to typescript version 2.6 and above
- Tested in typescript version 3.4, typescript above 3.4 may work but not guarantee.
- Typescript reference: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts