### PR TITLE
fix: add paymentMethodId for createEWalletCharge

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ ew.createEWalletCharge(data: {
   checkoutMethod: string;
   channelCode?: ChannelCode;
   channelProperties?: ChannelProps;
+  paymentMethodId?: string;
   customerID?: string;
   basket?: Basket[];
   metadata?: object;

--- a/src/ewallet/ewallet.d.ts
+++ b/src/ewallet/ewallet.d.ts
@@ -85,6 +85,7 @@ export = class EWallet {
     checkoutMethod: string;
     channelCode?: ChannelCode;
     channelProperties?: ChannelProps;
+    paymentMethodId?: string;
     customerID?: string;
     basket?: Basket[];
     metadata?: object;

--- a/src/ewallet/ewallet.js
+++ b/src/ewallet/ewallet.js
@@ -162,6 +162,7 @@ EWallet.prototype.createEWalletCharge = function(data) {
               redeem_points: data.channelProperties.redeemPoints,
             }
           : data.channelProperties,
+        payment_method_id: data.paymentMethodId,
         customer_id: data.customerID,
         basket: data.basket
           ? data.basket.map(product => ({


### PR DESCRIPTION
Context: https://xendit.slack.com/archives/C02BZU19CAX/p1632390581063300

Merchant experiencing error whereby `TOKENIZED_PAYMENT` is failing because the payment_method_id is not getting passed on to EWS V2