### PR TITLE
fix(qr_code): use JSON content type for simulation endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xendit-node",
-  "version": "1.21.6",
+  "version": "1.21.7",
   "description": "NodeJS client for Xendit API",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/qr_code/qr_code.js
+++ b/src/qr_code/qr_code.js
@@ -70,7 +70,10 @@ QrCode.prototype.simulate = function(data) {
       `${this.API_ENDPOINT}/${data.externalID}/payments/simulate`,
       {
         method: 'POST',
-        headers: { Authorization: Auth.basicAuthHeader(this.opts.secretKey) },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: Auth.basicAuthHeader(this.opts.secretKey),
+        },
         body: JSON.stringify({ amount: data.amount }),
       },
     )


### PR DESCRIPTION
Currently the request will fail since the default content type sent is `text/plain`