### PR TITLE
Draft: feat(payments): add forUserId param for payment request api

### DIFF
--- a/docs/PaymentRequest.md
+++ b/docs/PaymentRequest.md
@@ -30,6 +30,7 @@ const xenditPaymentRequestClient = new PaymentRequestClient({secretKey: YOUR_SEC
 |-----------|:----------:|:----------:|
 |  paymentRequestId| ✅ | string |
 |  idempotencyKey|  | string |
+|  forUserId|  | string |
 |  data|  | [PaymentRequestAuthParameters](payment_request/models/PaymentRequestAuthParameters.md) |
 
 ### Usage Examples
@@ -56,6 +57,7 @@ const response: PaymentRequest = await xenditPaymentRequestClient.authorizePayme
 |-----------|:----------:|:----------:|
 |  paymentRequestId| ✅ | string |
 |  idempotencyKey|  | string |
+|  forUserId|  | string |
 |  data|  | [CaptureParameters](payment_request/models/CaptureParameters.md) |
 
 ### Usage Examples
@@ -81,6 +83,7 @@ const response: Capture = await xenditPaymentRequestClient.capturePaymentRequest
 | Field Name |  Required  |   Type 	   |
 |-----------|:----------:|:----------:|
 |  idempotencyKey|  | string |
+|  forUserId|  | string |
 |  data|  | [PaymentRequestParameters](payment_request/models/PaymentRequestParameters.md) |
 
 ### Usage Examples
@@ -224,6 +227,7 @@ const response: PaymentRequest = await xenditPaymentRequestClient.createPaymentR
 |  beforeId|  | string |
 |  afterId|  | string |
 |  idempotencyKey|  | string |
+|  forUserId|  | string |
 
 ### Usage Examples
 #### Minimum API Usage
@@ -247,6 +251,7 @@ const response: PaymentRequestListResponse = await xenditPaymentRequestClient.ge
 |-----------|:----------:|:----------:|
 |  paymentRequestId| ✅ | string |
 |  idempotencyKey|  | string |
+|  forUserId|  | string |
 
 ### Usage Examples
 #### Minimum API Usage
@@ -273,6 +278,7 @@ const response: PaymentRequest = await xenditPaymentRequestClient.getPaymentRequ
 |  paymentRequestId| ✅ | string |
 |  limit|  | number |
 |  idempotencyKey|  | string |
+|  forUserId|  | string |
 
 ### Usage Examples
 #### Minimum API Usage
@@ -298,6 +304,7 @@ const response: CaptureListResponse = await xenditPaymentRequestClient.getPaymen
 |-----------|:----------:|:----------:|
 |  paymentRequestId| ✅ | string |
 |  idempotencyKey|  | string |
+|  forUserId|  | string |
 
 ### Usage Examples
 #### Minimum API Usage

--- a/payment_request/apis/PaymentRequest.ts
+++ b/payment_request/apis/PaymentRequest.ts
@@ -37,17 +37,20 @@ import {
 export interface AuthorizePaymentRequestRequest {
     paymentRequestId: string;
     idempotencyKey?: string;
+    forUserId?: string;
     data?: PaymentRequestAuthParameters;
 }
 
 export interface CapturePaymentRequestRequest {
     paymentRequestId: string;
     idempotencyKey?: string;
+    forUserId?: string;
     data?: CaptureParameters;
 }
 
 export interface CreatePaymentRequestRequest {
     idempotencyKey?: string;
+    forUserId?: string;
     data?: PaymentRequestParameters;
 }
 
@@ -59,22 +62,26 @@ export interface GetAllPaymentRequestsRequest {
     beforeId?: string;
     afterId?: string;
     idempotencyKey?: string;
+    forUserId?: string;
 }
 
 export interface GetPaymentRequestByIDRequest {
     paymentRequestId: string;
     idempotencyKey?: string;
+    forUserId?: string;
 }
 
 export interface GetPaymentRequestCapturesRequest {
     paymentRequestId: string;
     limit?: number;
     idempotencyKey?: string;
+    forUserId?: string;
 }
 
 export interface ResendPaymentRequestAuthRequest {
     paymentRequestId: string;
     idempotencyKey?: string;
+    forUserId?: string;
 }
 
 /**
@@ -111,6 +118,10 @@ export class PaymentRequestApi extends runtime.BaseAPI {
 
         if (requestParameters.idempotencyKey !== undefined && requestParameters.idempotencyKey !== null) {
             headerParameters['idempotency-key'] = String(requestParameters.idempotencyKey);
+        }
+
+        if (requestParameters.forUserId !== undefined && requestParameters.forUserId !== null) {
+            headerParameters['for-user-id'] = String(requestParameters.forUserId);
         }
 
         const response = await this.request({
@@ -153,6 +164,10 @@ export class PaymentRequestApi extends runtime.BaseAPI {
             headerParameters['idempotency-key'] = String(requestParameters.idempotencyKey);
         }
 
+        if (requestParameters.forUserId !== undefined && requestParameters.forUserId !== null) {
+            headerParameters['for-user-id'] = String(requestParameters.forUserId);
+        }
+
         const response = await this.request({
             path: `/payment_requests/{paymentRequestId}/captures`.replace(`{${"paymentRequestId"}}`, encodeURIComponent(String(requestParameters.paymentRequestId))),
             method: 'POST',
@@ -187,6 +202,10 @@ export class PaymentRequestApi extends runtime.BaseAPI {
 
         if (requestParameters.idempotencyKey !== undefined && requestParameters.idempotencyKey !== null) {
             headerParameters['idempotency-key'] = String(requestParameters.idempotencyKey);
+        }
+
+        if (requestParameters.forUserId !== undefined && requestParameters.forUserId !== null) {
+            headerParameters['for-user-id'] = String(requestParameters.forUserId);
         }
 
         const response = await this.request({
@@ -247,6 +266,10 @@ export class PaymentRequestApi extends runtime.BaseAPI {
             headerParameters['idempotency-key'] = String(requestParameters.idempotencyKey);
         }
 
+        if (requestParameters.forUserId !== undefined && requestParameters.forUserId !== null) {
+            headerParameters['for-user-id'] = String(requestParameters.forUserId);
+        }
+
         const response = await this.request({
             path: `/payment_requests`,
             method: 'GET',
@@ -282,6 +305,10 @@ export class PaymentRequestApi extends runtime.BaseAPI {
 
         if (requestParameters.idempotencyKey !== undefined && requestParameters.idempotencyKey !== null) {
             headerParameters['idempotency-key'] = String(requestParameters.idempotencyKey);
+        }
+
+        if (requestParameters.forUserId !== undefined && requestParameters.forUserId !== null) {
+            headerParameters['for-user-id'] = String(requestParameters.forUserId);
         }
 
         const response = await this.request({
@@ -325,6 +352,10 @@ export class PaymentRequestApi extends runtime.BaseAPI {
             headerParameters['idempotency-key'] = String(requestParameters.idempotencyKey);
         }
 
+        if (requestParameters.forUserId !== undefined && requestParameters.forUserId !== null) {
+            headerParameters['for-user-id'] = String(requestParameters.forUserId);
+        }
+
         const response = await this.request({
             path: `/payment_requests/{paymentRequestId}/captures`.replace(`{${"paymentRequestId"}}`, encodeURIComponent(String(requestParameters.paymentRequestId))),
             method: 'GET',
@@ -360,6 +391,10 @@ export class PaymentRequestApi extends runtime.BaseAPI {
 
         if (requestParameters.idempotencyKey !== undefined && requestParameters.idempotencyKey !== null) {
             headerParameters['idempotency-key'] = String(requestParameters.idempotencyKey);
+        }
+
+        if (requestParameters.forUserId !== undefined && requestParameters.forUserId !== null) {
+            headerParameters['for-user-id'] = String(requestParameters.forUserId);
         }
 
         const response = await this.request({


### PR DESCRIPTION
## Summary

This pull request add `for-user-id` header support for payment request api.

## Changes

- added an optional non-breaking feature to `payment_request/apis/PaymentRequest.ts`
- updated `docs/PaymentRequest.md`

## Tests

- [ ] `authorizePaymentRequest()`
- [ ] `capturePaymentRequest()`
- [x] `createPaymentRequest()`
- [ ] `getAllPaymentRequests()`
- [x] `getPaymentRequestByID()`
- [ ] `getPaymentRequestCaptures()`
- [ ] `resendPaymentRequestAuth()`