### PR TITLE
Update CreateInvoiceRequest.ts invoiceDuration to number data type

### DIFF
--- a/invoice/models/CreateInvoiceRequest.ts
+++ b/invoice/models/CreateInvoiceRequest.ts
@@ -70,10 +70,10 @@ export interface CreateInvoiceRequest {
     description?: string;
     /**
      * The duration of the invoice.
-     * @type {string}
+     * @type {number}
      * @memberof CreateInvoiceRequest
      */
-    invoiceDuration?: string;
+    invoiceDuration?: number;
     /**
      * The ID of the callback virtual account.
      * @type {string}


### PR DESCRIPTION
The data type of invoice duration is incorrect; it should be of type number, not string. Because when I passed a number in TypeScript, it was rejected by the CreateInvoiceRequest interface, since invoiceDuration?: string;

But when I provided a string, I got an API validation error: "invoice_duration" must be an integer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the type of the invoice duration field to use a numeric value instead of a string when creating invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->